### PR TITLE
Removed styles property

### DIFF
--- a/bundles/index.js
+++ b/bundles/index.js
@@ -291,7 +291,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	                useExisting: core_1.forwardRef(function () { return QuillEditorComponent_1; }),
 	                multi: true
 	            }],
-	        styles: ["\n    .ql-container .ql-editor {\n      min-height: 200px;\n      padding-bottom: 50px;\n    }\n  "],
 	        encapsulation: core_1.ViewEncapsulation.None
 	    }),
 	    __metadata("design:paramtypes", [core_1.ElementRef])

--- a/bundles/ngx-quill.umd.js
+++ b/bundles/ngx-quill.umd.js
@@ -291,7 +291,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	                useExisting: core_1.forwardRef(function () { return QuillEditorComponent_1; }),
 	                multi: true
 	            }],
-	        styles: ["\n    .ql-container .ql-editor {\n      min-height: 200px;\n      padding-bottom: 50px;\n    }\n  "],
 	        encapsulation: core_1.ViewEncapsulation.None
 	    }),
 	    __metadata("design:paramtypes", [core_1.ElementRef])

--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -35,12 +35,6 @@ import * as Quill from 'quill';
     useExisting: forwardRef(() => QuillEditorComponent),
     multi: true
   }],
-  styles: [`
-    .ql-container .ql-editor {
-      min-height: 200px;
-      padding-bottom: 50px;
-    }
-  `],
   encapsulation: ViewEncapsulation.None
 })
 export class QuillEditorComponent implements AfterViewInit, ControlValueAccessor, OnChanges, Validator {


### PR DESCRIPTION
Min-height and padding were not desired for my use case. The style property was making the ql-container too large.
```typescript
@Component({
  ...
  ...
  styles: [`
    .ql-container .ql-editor {
      min-height: 200px;
      padding-bottom: 50px;
    }
  `],
  ...
})
```

bubble.css and snow.css themes already have height of 100%
```css
.ql-container {
  box-sizing: border-box;
  font-family: Helvetica, Arial, sans-serif;
  font-size: 13px;
  height: 100%;
  margin: 0px;
  position: relative;
}
```