### PR TITLE
fix(typescript): TS2322: Type 'null' is not assignable to type 'strin…

### DIFF
--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -126,7 +126,7 @@ export class QuillEditorComponent implements AfterViewInit, ControlValueAccessor
 
     // update model if text changes
     this.quillEditor.on('text-change', (delta: any, oldDelta: any, source: string) => {
-      let html = this.editorElem.children[0].innerHTML;
+      let html: (string | null) = this.editorElem.children[0].innerHTML;
       const text = this.quillEditor.getText();
 
       if (html === '<p><br></p>') {


### PR DESCRIPTION
…g|void'

let html: (string | null) = ... instead of let html = ... because the default
behaviour is html: (string)