### PR TITLE
Added type to variable modules

### DIFF
--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -87,7 +87,7 @@ export class QuillEditorComponent implements AfterViewInit, ControlValueAccessor
 
   ngAfterViewInit() {
     const toolbarElem = this.elementRef.nativeElement.querySelector('[quill-editor-toolbar]');
-    let modules = this.modules || this.defaultModules;
+    let modules: any = this.modules || this.defaultModules;
 
     if (toolbarElem) {
       modules['toolbar'] = toolbarElem;


### PR DESCRIPTION
Changed the variable module to type 'any' to fix a problem when running a linter
Element implicitly has an 'any' type because type 'Object' has no index signature.