### PR TITLE
Fix: add bounds option in Quill construtor

### DIFF
--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -105,7 +105,8 @@ export class QuillEditorComponent implements AfterViewInit, ControlValueAccessor
       placeholder: placeholder,
       readOnly: this.readOnly || false,
       theme: this.theme || 'snow',
-      formats: this.formats
+      formats: this.formats,
+      bounds: this.bounds || document.body
     });
 
     if (this.content) {


### PR DESCRIPTION
The bounds option is needed during the contractor for the bubble theme.