### PR TITLE
added ability to use a value getter/setter for formcontrol

### DIFF
--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -99,12 +99,8 @@ export class QuillEditorComponent
   @Output() onEditorCreated: EventEmitter<any> = new EventEmitter();
   @Output() onContentChanged: EventEmitter<any> = new EventEmitter();
   @Output() onSelectionChanged: EventEmitter<any> = new EventEmitter();
-
-  onModelChange: Function = () => {};
-  onModelTouched: Function = () => {};
-
   @Input()
-  valueGetter: Function = (quillEditor: any, editorElement: HTMLElement) => {
+  valueGetter = (quillEditor: any, editorElement: HTMLElement): any => {
     let html: string | null = editorElement.children[0].innerHTML;
     if (html === '<p><br></p>' || html === '<div><br><div>') {
       html = null;
@@ -112,9 +108,12 @@ export class QuillEditorComponent
     return html;
   };
   @Input()
-  valueSetter: Function = (quillEditor: any, value: any) => {
+  valueSetter = (quillEditor: any, value: any): any => {
     return quillEditor.clipboard.convert(value);
   };
+
+  onModelChange: Function = () => {};
+  onModelTouched: Function = () => {};
 
   constructor(
     private elementRef: ElementRef,
@@ -199,6 +198,7 @@ export class QuillEditorComponent
     this.quillEditor.on(
       'text-change',
       (delta: any, oldDelta: any, source: string) => {
+
         const text = this.quillEditor.getText();
 
         let html: string | null = this.editorElem.children[0].innerHTML;


### PR DESCRIPTION
this change gives us the power to manipulate the value which is passed to the formcontrol

the default behavior didn't change. Set/Get is HTML. But if you use own Blots, the HTML conversion doesn't really work well.

eg of usage:

IN TS:
`
getQuillValue(quill, elementRef) {
    return JSON.stringify(quill.getContents());
  }
  setQuillValue(quill, value) {
    try {
      return JSON.parse(value);
    } catch (err) {
      return '';
    }
  }
`

IN HTML:
`<quill-editor [formControl]="formControl" [valueGetter]="getQuillValue" [valueSetter]="setQuillValue"></quill-editor>`