### PR TITLE
upd: SSR compatibility

### DIFF
--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -26,8 +26,11 @@ import {
 
 import { DOCUMENT } from '@angular/common';
 
-import * as QuillNamespace from 'quill';
-let Quill: any = QuillNamespace;
+// import * as QuillNamespace from 'quill';
+// Because quill uses `document` directly, we cannot `import` during SSR
+// instead, we load dynamically via `require('quill')` in `ngAfterViewInit()`
+declare var require: any;
+var Quill: any = undefined;
 
 export interface CustomOption {
   import: string;
@@ -130,6 +133,9 @@ export class QuillEditorComponent
   ngAfterViewInit() {
     if (isPlatformServer(this.platformId)) {
       return;
+    }
+    else if (!Quill) {
+      Quill = require('quill');
     }
 
     const toolbarElem = this.elementRef.nativeElement.querySelector(
@@ -235,7 +241,7 @@ export class QuillEditorComponent
 
   ngOnChanges(changes: SimpleChanges): void {
     if (!this.quillEditor) {
-      return null;
+      return;
     }
     if (changes['readOnly']) {
       this.quillEditor.enable(!changes['readOnly'].currentValue);


### PR DESCRIPTION
fixes #159

Even with `if (isPlatformServer(this.platformId))`, SSR doesn't work because loading quill via `import * as Quill from 'quill'` runs code which calls `document` directly (and throws an error).

This change instead loads quill dynamically only on the browser side. I'm not familiar enough with JS modules to know what affect, if any, using `require('quill')` vs `import 'quill'` will have on tree shaking / optimizing code.