### PR TITLE
Optional global config

### DIFF
--- a/src/quill-editor.component.spec.ts
+++ b/src/quill-editor.component.spec.ts
@@ -7,6 +7,15 @@ import { QuillEditorComponent } from '../src/quill-editor.component';
 import * as QuillNamespace from 'quill';
 let Quill: any = QuillNamespace;
 
+beforeEach(() => {
+  TestBed.configureTestingModule({ providers: [
+    {
+      provide: 'config',
+      useValue: undefined
+    }
+  ] });
+});
+
 @Component({
   template: `
 <quill-editor [(ngModel)]="title" [customOptions]="[{import: 'attributors/style/size', whitelist: ['14']}]" [style]="{height: '30px'}" [required]="required" [minLength]="minLength" [maxLength]="maxLength" [readOnly]="isReadOnly" (onEditorCreated)="handleEditorCreated($event)" (onContentChanged)="handleChange($event);" (onSelectionChanged)="handleSelection($event);"></quill-editor>

--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -1,4 +1,4 @@
-import { Config } from './quill-editor.interfaces';
+import { QuillConfig, QuillModules } from './quill-editor.interfaces';
 import { isPlatformServer } from '@angular/common';
 
 import {
@@ -66,7 +66,7 @@ export class QuillEditorComponent
   content: any;
   selectionChangeEvent: any;
   textChangeEvent: any;
-   defaultModules: Config = this.config || {
+  defaultModules: QuillModules = {
     toolbar: [
       ['bold', 'italic', 'underline', 'strike'], // toggled buttons
       ['blockquote', 'code-block'],
@@ -97,7 +97,7 @@ export class QuillEditorComponent
 
   @Input() format: 'object' | 'html' | 'text' | 'json' = 'html';
   @Input() theme: string;
-  @Input() modules: { [index: string]: Object };
+  @Input() modules: QuillModules;
   @Input() readOnly: boolean;
   @Input() placeholder: string;
   @Input() maxLength: number;
@@ -161,8 +161,10 @@ export class QuillEditorComponent
     @Inject(PLATFORM_ID) private platformId: Object,
     private renderer: Renderer2,
     private zone: NgZone,
-    @Inject('config') private config: Config,
-  ) {}
+    @Inject('config') private config: QuillConfig,
+  ) {
+    this.defaultModules = this.config && this.config.modules || this.defaultModules;
+  }
 
   ngAfterViewInit() {
     if (isPlatformServer(this.platformId)) {
@@ -175,7 +177,7 @@ export class QuillEditorComponent
     const toolbarElem = this.elementRef.nativeElement.querySelector(
       '[quill-editor-toolbar]'
     );
-    let modules: any = this.modules || this.defaultModules;
+    let modules: QuillModules = this.modules || this.defaultModules;
     let placeholder = 'Insert text here ...';
 
     if (this.placeholder !== null && this.placeholder !== undefined) {

--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -1,3 +1,4 @@
+import { Config } from './quill-editor.interfaces';
 import { isPlatformServer } from '@angular/common';
 
 import {
@@ -65,7 +66,7 @@ export class QuillEditorComponent
   content: any;
   selectionChangeEvent: any;
   textChangeEvent: any;
-  defaultModules = {
+   defaultModules: Config = this.config || {
     toolbar: [
       ['bold', 'italic', 'underline', 'strike'], // toggled buttons
       ['blockquote', 'code-block'],
@@ -159,7 +160,8 @@ export class QuillEditorComponent
     @Inject(DOCUMENT) private doc: any,
     @Inject(PLATFORM_ID) private platformId: Object,
     private renderer: Renderer2,
-    private zone: NgZone
+    private zone: NgZone,
+    @Inject('config') private config: Config,
   ) {}
 
   ngAfterViewInit() {

--- a/src/quill-editor.interfaces.ts
+++ b/src/quill-editor.interfaces.ts
@@ -1,14 +1,20 @@
-export interface Config {
-    [key: string]: ((string | {
-        indent?: string;
-        list?: string;
-        direction?: string;
-        header?: number | (boolean | number)[];
-        color?: string[];
-        background?: string[];
-        align?: string[];
-        script?: string;
-        font?: string[];
-        size?: (boolean | string)[];
-    })[])[];
+export type QuillToolbarConfig = ((string | {
+    indent?: string;
+    list?: string;
+    direction?: string;
+    header?: number | (boolean | number)[];
+    color?: string[];
+    background?: string[];
+    align?: string[];
+    script?: string;
+    font?: string[];
+    size?: (boolean | string)[];
+})[])[];
+
+export type QuillModules = {
+    toolbar: QuillToolbarConfig;
+}
+
+export interface QuillConfig {
+    modules: QuillModules;
 }

--- a/src/quill-editor.interfaces.ts
+++ b/src/quill-editor.interfaces.ts
@@ -1,0 +1,14 @@
+export interface Config {
+    [key: string]: ((string | {
+        indent?: string;
+        list?: string;
+        direction?: string;
+        header?: number | (boolean | number)[];
+        color?: string[];
+        background?: string[];
+        align?: string[];
+        script?: string;
+        font?: string[];
+        size?: (boolean | string)[];
+    })[])[];
+}

--- a/src/quill.module.ts
+++ b/src/quill.module.ts
@@ -1,4 +1,4 @@
-import { Config } from './quill-editor.interfaces';
+import { QuillConfig } from './quill-editor.interfaces';
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { QuillEditorComponent } from './quill-editor.component';
@@ -9,10 +9,15 @@ import { QuillEditorComponent } from './quill-editor.component';
   ],
   imports: [],
   exports: [QuillEditorComponent],
-  providers: []
+  providers: [
+    {
+      provide: 'config',
+      useValue: undefined,
+    }
+  ]
 })
 export class QuillModule {
-  static forRoot(config: Config): ModuleWithProviders {
+  static forRoot(config: QuillConfig): ModuleWithProviders {
     return {
       ngModule: QuillModule,
       providers: [

--- a/src/quill.module.ts
+++ b/src/quill.module.ts
@@ -1,4 +1,5 @@
-import { NgModule } from '@angular/core';
+import { Config } from './quill-editor.interfaces';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { QuillEditorComponent } from './quill-editor.component';
 
@@ -10,4 +11,16 @@ import { QuillEditorComponent } from './quill-editor.component';
   exports: [QuillEditorComponent],
   providers: []
 })
-export class QuillModule { }
+export class QuillModule {
+  static forRoot(config: Config): ModuleWithProviders {
+    return {
+      ngModule: QuillModule,
+      providers: [
+        {
+          provide: 'config',
+          useValue: config,
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Regarding the following request I added the support with minimal update by using module forRoot pattern. 
One can use the global config by 
`QuillEditorModule.forRoot(config)`
at app.module.ts

Related issue/enhancement:
Define global config #171 

