### PR TITLE
Avoid calling onModelChange for programmatic changes

### DIFF
--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -261,9 +261,12 @@ export class QuillEditorComponent
         }
 
         this.zone.run(() => {
-          this.onModelChange(
-            this.valueGetter(this.quillEditor, this.editorElem)
-          );
+
+          if (source === 'user') {
+            this.onModelChange(
+              this.valueGetter(this.quillEditor, this.editorElem)
+            );
+          }
 
           this.onContentChanged.emit({
             editor: this.quillEditor,


### PR DESCRIPTION
Fixes https://github.com/KillerCodeMonkey/ngx-quill/issues/121.

This PR contains additional unit tests to check how ngx-quill reacts both to programmatic changes and user changes. Note that the logic of existing tests were not modified at all, which means that this PR does not break anything the component users's should have relied on.