### PR TITLE
fix: correctly set the default module config value; use injection token.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export * from './src/quill.module';
 export * from './src/quill-editor.component';
+export * from './src/quill-editor.interfaces';

--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -1,7 +1,7 @@
 import { isPlatformServer } from '@angular/common'
 import { DomSanitizer } from '@angular/platform-browser'
 
-import { QuillConfig, QuillModules } from './quill-editor.interfaces'
+import { QUILL_CONFIG_TOKEN, QuillConfig, QuillModules } from './quill-editor.interfaces'
 
 import {
   AfterViewInit,
@@ -107,7 +107,7 @@ export class QuillEditorComponent
     @Inject(PLATFORM_ID) private platformId: Object,
     private renderer: Renderer2,
     private zone: NgZone,
-    @Inject('config') private config: QuillConfig
+    @Inject(QUILL_CONFIG_TOKEN) private config: QuillConfig
   ) {
     this.defaultModules = this.config && this.config.modules || {}
     this.bounds = this.doc.body

--- a/src/quill-editor.interfaces.ts
+++ b/src/quill-editor.interfaces.ts
@@ -1,3 +1,5 @@
+import { InjectionToken } from '@angular/core'
+
 export type QuillToolbarConfig = Array<Array<
   string | {
     indent?: string
@@ -21,3 +23,5 @@ export interface QuillModules {
 export interface QuillConfig {
   modules?: QuillModules
 }
+
+export const QUILL_CONFIG_TOKEN = new InjectionToken<QuillConfig>('config')

--- a/src/quill.module.ts
+++ b/src/quill.module.ts
@@ -1,7 +1,7 @@
 import { ModuleWithProviders, NgModule } from '@angular/core'
 
 import { QuillEditorComponent } from './quill-editor.component'
-import { QuillConfig } from './quill-editor.interfaces'
+import { QUILL_CONFIG_TOKEN, QuillConfig } from './quill-editor.interfaces'
 
 const emptyArray: any[] = []
 const defaultModules = {
@@ -39,8 +39,8 @@ const defaultModules = {
   imports: [],
   providers: [
     {
-      provide: 'config',
-      useValue: defaultModules
+      provide: QUILL_CONFIG_TOKEN,
+      useValue: { modules: defaultModules }
     }
   ]
 })
@@ -50,8 +50,8 @@ export class QuillModule {
       ngModule: QuillModule,
       providers: [
         {
-          provide: 'config',
-          useValue: config || defaultModules
+          provide: QUILL_CONFIG_TOKEN,
+          useValue: config || { modules: defaultModules }
         }
       ]
     }


### PR DESCRIPTION
(1) correctly set the default module config value; 
(2) use injection token for ModuleWithProviders;
(3) export QuillConfig interfaces

This pull request has locally run through "pretest" and "test".