### PR TITLE
Require Node >= 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/KillerCodeMonkey/ngx-quill"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 8"
   },
   "scripts": {
     "lint": "tslint --force \"src/**/*.ts\"",


### PR DESCRIPTION
According to the (Angular docs](https://angular.io/guide/quickstart#nodejs), Node 8+ is still supported. I don't know if you're relying on Node 10 specific code, you you should consider modifying it to support Node 8. This flag prevents `yarn` from installing `ngx-quill` without Node 10+.