### PR TITLE
Fix click handler not removed after ngOnDestroy

### DIFF
--- a/src/quill-editor.component.ts
+++ b/src/quill-editor.component.ts
@@ -372,6 +372,7 @@ export class QuillEditorComponent
     if (this.quillEditor) {
       this.quillEditor.off('selection-change', this.selectionChangeHandler)
       this.quillEditor.off('text-change', this.textChangeHandler)
+      this.quillEditor.off('click')
     }
   }
 


### PR DESCRIPTION
Fix click handler added by quill (for links) not destroyed after ngOnDestroy, preventing clicks on links everywhere.