### PR TITLE
QuillToolbarConfigs with buttons and dropdown

### DIFF
--- a/src/quill-editor.interfaces.ts
+++ b/src/quill-editor.interfaces.ts
@@ -5,11 +5,11 @@ export type QuillToolbarConfig = Array<Array< string | {
   list?: string
   direction?: string
   header?: number | Array<boolean | number>
-  color?: string[]
-  background?: string[]
-  align?: string[]
+  color?: string[] | string
+  background?: string[] | string
+  align?: string[] | string
   script?: string
-  font?: string[]
+  font?: string[] | string
   size?: Array<boolean | string>
 }
 >>


### PR DESCRIPTION
The properties `color`, `background`, `align` and `font` in `QuillToobarConfig` has so far only accepted arrays of strings, making them dropdowns. Sometimes, you want to show the different options directly on the toolbar instead of requiring the user to open a dropdown with the options. For instance, you may want to show all the `align` buttons directly on the toolbar. 

So instead of writing this, which would result in a dropdown with 4 options
`[{ 'align': ['', 'center', 'right', 'justify' ]}]`

You would write this, which would lead to 4 buttons showing in the toolbar
`[{ 'align': '' }, { 'align': 'center' }, { 'align': 'right' }, { 'align': 'justify' }]`

This is actually supported in Quill, but the typescript definition in this file doesn't accept it, so you will get a compile error although it will run fine. You can watch it in action here: https://codepen.io/poosham/pen/poojvOM