### PR TITLE
Execute value setter during init

### DIFF
--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -1071,12 +1071,12 @@ describe('Advanced QuillEditorComponent', () => {
   })
 
   it('should render custom link placeholder', async () => {
-    const fixture = TestBed.createComponent(CustomLinkPlaceholderTestComponent) as ComponentFixture<CustomLinkPlaceholderTestComponent>
+    const linkFixture = TestBed.createComponent(CustomLinkPlaceholderTestComponent) as ComponentFixture<CustomLinkPlaceholderTestComponent>
 
-    fixture.detectChanges()
-    await fixture.whenStable()
-    
-    const el = fixture.nativeElement.querySelector('input[data-link]');
+    linkFixture.detectChanges()
+    await linkFixture.whenStable()
+
+    const el = linkFixture.nativeElement.querySelector('input[data-link]')
 
     expect(el.dataset.link).toBe('https://test.de')
   })

--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -158,6 +158,17 @@ class CustomModuleTestComponent {
   impl = CustomModule
 }
 
+@Component({
+  template: `
+    <quill-editor [ngModel]="content" [linkPlaceholder]="'https://test.de'"></quill-editor>
+`
+})
+class CustomLinkPlaceholderTestComponent {
+  @ViewChild(QuillEditorComponent, { static: true }) editor!: QuillEditorComponent
+  content = ''
+}
+
+
 describe('Basic QuillEditorComponent', () => {
   let fixture: ComponentFixture<QuillEditorComponent>
 
@@ -700,7 +711,7 @@ describe('Advanced QuillEditorComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      declarations: [TestComponent, TestToolbarComponent],
+      declarations: [TestComponent, TestToolbarComponent, CustomLinkPlaceholderTestComponent],
       imports: [FormsModule, QuillModule],
       providers: QuillModule.forRoot().providers
     }).compileComponents()
@@ -1057,6 +1068,17 @@ describe('Advanced QuillEditorComponent', () => {
 
     const editorComponent = toolbarFixture.debugElement.children[0].componentInstance
     expect(editorComponent.customToolbarPosition).toEqual('bottom')
+  })
+
+  it('should render custom link placeholder', async () => {
+    const fixture = TestBed.createComponent(CustomLinkPlaceholderTestComponent) as ComponentFixture<CustomLinkPlaceholderTestComponent>
+
+    fixture.detectChanges()
+    await fixture.whenStable()
+    
+    const el = fixture.nativeElement.querySelector('input[data-link]');
+
+    expect(el.dataset.link).toBe('https://test.de')
   })
 })
 

--- a/projects/ngx-quill/src/lib/quill-editor.component.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.ts
@@ -91,9 +91,9 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
   @Input() preserveWhitespace = false
   @Input() classes?: string
   @Input() trimOnValidation = false
-  @Input() linkPlaceholder?: string;
-  @Input() compareValues = false;
-  @Input() filterNull = false;
+  @Input() linkPlaceholder?: string
+  @Input() compareValues = false
+  @Input() filterNull = false
 
   @Output() onEditorCreated: EventEmitter<any> = new EventEmitter()
   @Output() onEditorChanged: EventEmitter<EditorChangeContent | EditorChangeSelection> = new EventEmitter()
@@ -267,29 +267,29 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
         scrollingContainer: scrollingContainer as any,
         strict: this.strict,
         theme: this.theme || (this.service.config.theme ? this.service.config.theme : 'snow')
-      });
+      })
 
       // Set optional link placeholder, Quill has no native API for it so using workaround
       if (this.linkPlaceholder) {
-        const tooltip = (this.quillEditor as any)?.theme?.tooltip;
-        const input = tooltip?.root?.querySelector('input[data-link]');
+        const tooltip = (this.quillEditor as any)?.theme?.tooltip
+        const input = tooltip?.root?.querySelector('input[data-link]')
         if (input?.dataset) {
-          input.dataset.link = this.linkPlaceholder;
+          input.dataset.link = this.linkPlaceholder
         }
       }
     })
 
     if (this.content) {
-      const format = getFormat(this.format, this.service.config.format);
+      const format = getFormat(this.format, this.service.config.format)
 
       if (format === 'text') {
-        this.quillEditor.setText(this.content, 'silent');
+        this.quillEditor.setText(this.content, 'silent')
       } else {
-        const newValue = this.valueSetter(this.quillEditor, this.content);
-        this.quillEditor.setContents(newValue, 'silent');
+        const newValue = this.valueSetter(this.quillEditor, this.content)
+        this.quillEditor.setContents(newValue, 'silent')
       }
 
-      this.quillEditor.getModule('history').clear();
+      this.quillEditor.getModule('history').clear()
     }
 
     // initialize disabled status based on this.disabled as default value
@@ -506,35 +506,35 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
 
     // optional fix for https://github.com/angular/angular/issues/14988
     if(this.filterNull && currentValue === null){
-      return;
+      return
     }
 
-    this.content = currentValue;
+    this.content = currentValue
 
     if(!this.quillEditor){
-      return;
+      return
     }
 
-    const format = getFormat(this.format, this.service.config.format);
-    const newValue = this.valueSetter(this.quillEditor, currentValue);
+    const format = getFormat(this.format, this.service.config.format)
+    const newValue = this.valueSetter(this.quillEditor, currentValue)
 
     if(this.compareValues){
-     const currentEditorValue = this.quillEditor.getContents();
+     const currentEditorValue = this.quillEditor.getContents()
       if (JSON.stringify(currentEditorValue) === JSON.stringify(newValue)) {
-        return;
+        return
       }
     }
 
     if (currentValue) {
       if (format === 'text') {
-        this.quillEditor.setText(currentValue);
+        this.quillEditor.setText(currentValue)
       } else {
-        this.quillEditor.setContents(newValue);
+        this.quillEditor.setContents(newValue)
       }
-      return;
+      return
     }
-    this.quillEditor.setText('');
-  
+    this.quillEditor.setText('')
+
 
   }
 

--- a/projects/ngx-quill/src/lib/quill-editor.component.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.ts
@@ -505,20 +505,20 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
   writeValue(currentValue: any) {
 
     // optional fix for https://github.com/angular/angular/issues/14988
-    if(this.filterNull && currentValue === null){
+    if (this.filterNull && currentValue === null) {
       return
     }
 
     this.content = currentValue
 
-    if(!this.quillEditor){
+    if (!this.quillEditor) {
       return
     }
 
     const format = getFormat(this.format, this.service.config.format)
     const newValue = this.valueSetter(this.quillEditor, currentValue)
 
-    if(this.compareValues){
+    if (this.compareValues) {
      const currentEditorValue = this.quillEditor.getContents()
       if (JSON.stringify(currentEditorValue) === JSON.stringify(newValue)) {
         return
@@ -534,7 +534,6 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
       return
     }
     this.quillEditor.setText('')
-
 
   }
 

--- a/projects/ngx-quill/src/lib/quill-editor.component.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.ts
@@ -91,6 +91,9 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
   @Input() preserveWhitespace = false
   @Input() classes?: string
   @Input() trimOnValidation = false
+  @Input() linkPlaceholder?: string;
+  @Input() compareValues = false;
+  @Input() filterNull = false;
 
   @Output() onEditorCreated: EventEmitter<any> = new EventEmitter()
   @Output() onEditorChanged: EventEmitter<EditorChangeContent | EditorChangeSelection> = new EventEmitter()
@@ -264,30 +267,29 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
         scrollingContainer: scrollingContainer as any,
         strict: this.strict,
         theme: this.theme || (this.service.config.theme ? this.service.config.theme : 'snow')
-      })
+      });
+
+      // Set optional link placeholder, Quill has no native API for it so using workaround
+      if (this.linkPlaceholder) {
+        const tooltip = (this.quillEditor as any)?.theme?.tooltip;
+        const input = tooltip?.root?.querySelector('input[data-link]');
+        if (input?.dataset) {
+          input.dataset.link = this.linkPlaceholder;
+        }
+      }
     })
 
     if (this.content) {
-      const format = getFormat(this.format, this.service.config.format)
-      if (format === 'object') {
-        this.quillEditor.setContents(this.content, 'silent')
-      } else if (format === 'text') {
-        this.quillEditor.setText(this.content, 'silent')
-      } else if (format === 'json') {
-        try {
-          this.quillEditor.setContents(JSON.parse(this.content), 'silent')
-        } catch (e) {
-          this.quillEditor.setText(this.content, 'silent')
-        }
+      const format = getFormat(this.format, this.service.config.format);
+
+      if (format === 'text') {
+        this.quillEditor.setText(this.content, 'silent');
       } else {
-        if (this.sanitize) {
-          this.content = this.domSanitizer.sanitize(SecurityContext.HTML, this.content)
-        }
-        const contents = this.quillEditor.clipboard.convert(this.content)
-        this.quillEditor.setContents(contents, 'silent')
+        const newValue = this.valueSetter(this.quillEditor, this.content);
+        this.quillEditor.setContents(newValue, 'silent');
       }
 
-      this.quillEditor.getModule('history').clear()
+      this.quillEditor.getModule('history').clear();
     }
 
     // initialize disabled status based on this.disabled as default value
@@ -501,22 +503,39 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
   }
 
   writeValue(currentValue: any) {
-    this.content = currentValue
-    const format = getFormat(this.format, this.service.config.format)
 
-    if (this.quillEditor) {
-      if (currentValue) {
-        if (format === 'text') {
-          this.quillEditor.setText(currentValue)
-        } else {
-          this.quillEditor.setContents(
-            this.valueSetter(this.quillEditor, this.content)
-          )
-        }
-        return
-      }
-      this.quillEditor.setText('')
+    // optional fix for https://github.com/angular/angular/issues/14988
+    if(this.filterNull && currentValue === null){
+      return;
     }
+
+    this.content = currentValue;
+
+    if(!this.quillEditor){
+      return;
+    }
+
+    const format = getFormat(this.format, this.service.config.format);
+    const newValue = this.valueSetter(this.quillEditor, currentValue);
+
+    if(this.compareValues){
+     const currentEditorValue = this.quillEditor.getContents();
+      if (JSON.stringify(currentEditorValue) === JSON.stringify(newValue)) {
+        return;
+      }
+    }
+
+    if (currentValue) {
+      if (format === 'text') {
+        this.quillEditor.setText(currentValue);
+      } else {
+        this.quillEditor.setContents(newValue);
+      }
+      return;
+    }
+    this.quillEditor.setText('');
+  
+
   }
 
   setDisabledState(isDisabled: boolean = this.disabled): void {


### PR DESCRIPTION
Fixed #1149

I also added a Custom link placeholder and the option to compare the values in the writeValue function to minimize dom interaction.
Link placeholder and the compare functions are disabled by default, but can be enabled via inputs.