### PR TITLE
Add onEditorCreated method to quill-view component

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ As a helper `ngx-quill` provides a component where you can pass many options of 
 - preserveWhitespace - default: false - possbility to use a pre-tag instead of a div-tag for the contenteditable area to preserve duplicated whitespaces | caution if used with syntax plugin [Related issue](https://github.com/quilljs/quill/issues/1751)
 - sanitize - uses angulars DomSanitizer to santize html values - default: `false`, boolean (only for format="html")
 
+### Outputs
+
+- onEditorCreated - editor instance
+
 ```HTML
 <quill-view [content]="content" format="text" theme="snow"></quill-view>
 ```

--- a/projects/ngx-quill/src/lib/quill-view.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-view.component.spec.ts
@@ -239,3 +239,45 @@ describe('Formats', () => {
     })
   })
 })
+
+describe('Advanced QuillViewComponent', () => {
+
+  @Component({
+    template: `
+  <quill-view [content]="content" format="html" (onEditorCreated)="handleEditorCreated($event)"></quill-view>
+  `
+  })
+  class AdvancedComponent {
+    @ViewChild(QuillViewComponent, {static: true}) view: QuillViewComponent | undefined
+    content = '<p>Hallo</p>'
+    quillEditor: any
+
+    handleEditorCreated(event: any) {
+      this.quillEditor = event
+    }
+  }
+
+  let fixture: ComponentFixture<AdvancedComponent>
+
+  beforeEach(async () => {
+
+    TestBed.configureTestingModule({
+      declarations: [AdvancedComponent],
+      imports: [QuillModule],
+      providers: QuillModule.forRoot().providers
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(AdvancedComponent) as ComponentFixture<AdvancedComponent>
+  })
+
+  it('should emit onEditorCreated with editor instance',  async () => {
+
+    spyOn(fixture.componentInstance, 'handleEditorCreated')
+    fixture.detectChanges()
+
+    await fixture.whenStable()
+
+    const viewComponent = fixture.debugElement.children[0].componentInstance
+    expect(fixture.componentInstance.handleEditorCreated).toHaveBeenCalledWith(viewComponent.quillEditor)
+  })
+})

--- a/projects/ngx-quill/src/lib/quill-view.component.ts
+++ b/projects/ngx-quill/src/lib/quill-view.component.ts
@@ -6,8 +6,10 @@ import {
   AfterViewInit,
   Component,
   ElementRef,
+  EventEmitter,
   Inject,
   Input,
+  Output,
   OnChanges,
   PLATFORM_ID,
   Renderer2,
@@ -45,6 +47,8 @@ export class QuillViewComponent implements AfterViewInit, OnChanges {
   @Input() customModules: CustomModule[] = []
   @Input() customOptions: CustomOption[] = []
   @Input() preserveWhitespace = false
+
+  @Output() onEditorCreated: EventEmitter<any> = new EventEmitter()
 
   quillEditor!: QuillType
   editorElem!: HTMLElement
@@ -147,5 +151,10 @@ export class QuillViewComponent implements AfterViewInit, OnChanges {
     if (this.content) {
       this.valueSetter(this.quillEditor, this.content)
     }
+
+    // trigger created in a timeout to avoid changed models after checked
+    setTimeout(() => {
+      this.onEditorCreated.emit(this.quillEditor)
+    })
   }
 }


### PR DESCRIPTION
Hi, 

As discussed in this [issue ](https://github.com/KillerCodeMonkey/ngx-quill/issues/1165) 
Here is an addition of `onEditorCreated` method to `quill-view` component as it's made in `quill-editor` component

Tell me if I should change or add something.