### PR TITLE
perf: unpatch `document.addEventListener` when the `quill` is imported

### DIFF
--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -969,10 +969,10 @@ describe('Advanced QuillEditorComponent', () => {
     fixture.detectChanges()
     tick(200)
 
-    spyOn(editorFixture.componentInstance.doc.defaultView, 'clearTimeout').and.callThrough()
+    spyOn(editorFixture.componentInstance.document.defaultView, 'clearTimeout').and.callThrough()
     editorFixture.componentInstance.ngOnDestroy()
 
-    expect(editorFixture.componentInstance.doc.defaultView.clearTimeout).toHaveBeenCalledTimes(2)
+    expect(editorFixture.componentInstance.document.defaultView.clearTimeout).toHaveBeenCalledTimes(2)
     expect(editorFixture.componentInstance.debounceTimers.length).toBe(0)
   }))
 

--- a/projects/ngx-quill/src/lib/quill-editor.component.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.ts
@@ -13,6 +13,7 @@ import {
   EventEmitter,
   forwardRef,
   Inject,
+  Injector,
   Input,
   NgZone,
   OnChanges,
@@ -130,16 +131,19 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
   private editorChangeHandlerRef: typeof QuillEditorBase.prototype.editorChangeHandler
   private textChangeHandlerRef: typeof QuillEditorBase.prototype.textChangeHandler
   private debounceTimers: number[] = []
+  private document: Document
 
   constructor(
+    injector: Injector,
     public elementRef: ElementRef,
     protected domSanitizer: DomSanitizer,
-    @Inject(DOCUMENT) protected doc: any,
     @Inject(PLATFORM_ID) protected platformId: any,
     protected renderer: Renderer2,
     protected zone: NgZone,
     protected service: QuillService
-  ) {}
+  ) {
+    this.document = injector.get(DOCUMENT)
+  }
 
   static normalizeClassNames(classes: string): string[] {
     const classList = classes.trim().split(' ')
@@ -251,7 +255,7 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
 
     let bounds = this.bounds && this.bounds === 'self' ? this.editorElem : this.bounds
     if (!bounds) {
-      bounds = this.service.config.bounds ? this.service.config.bounds : this.doc.body
+      bounds = this.service.config.bounds ? this.service.config.bounds : this.document.body
     }
 
     let debug = this.debug
@@ -666,7 +670,7 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
 
       this.clearDebounceTimer(timer)
 
-      timer = this.doc.defaultView.setTimeout(() => {
+      timer = this.document.defaultView.setTimeout(() => {
         this.clearDebounceTimer(timer)
 
         callback(...args)
@@ -676,7 +680,7 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
   }
 
   private clearDebounceTimer(timer: number): void {
-    this.doc.defaultView.clearTimeout(timer)
+    this.document.defaultView.clearTimeout(timer)
     this.debounceTimers = this.debounceTimers.filter((debounceTimer) => debounceTimer !== timer)
   }
 }
@@ -705,18 +709,18 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
 export class QuillEditorComponent extends QuillEditorBase {
 
   constructor(
+    injector: Injector,
     @Inject(ElementRef) elementRef: ElementRef,
     @Inject(DomSanitizer) domSanitizer: DomSanitizer,
-    @Inject(DOCUMENT) doc: any,
     @Inject(PLATFORM_ID) platformId: any,
     @Inject(Renderer2) renderer: Renderer2,
     @Inject(NgZone) zone: NgZone,
     @Inject(QuillService) service: QuillService
   ) {
     super(
+      injector,
       elementRef,
       domSanitizer,
-      doc,
       platformId,
       renderer,
       zone,

--- a/projects/ngx-quill/src/lib/quill.service.ts
+++ b/projects/ngx-quill/src/lib/quill.service.ts
@@ -1,6 +1,8 @@
-import { Injectable, Inject } from '@angular/core'
-import { QUILL_CONFIG_TOKEN, QuillConfig } from './quill-editor.interfaces'
+import { DOCUMENT } from '@angular/common'
+import { Injectable, Inject, Injector } from '@angular/core'
+
 import { defaultModules } from './quill-defaults'
+import { QUILL_CONFIG_TOKEN, QuillConfig } from './quill-editor.interfaces'
 
 @Injectable({
   providedIn: 'root'
@@ -10,10 +12,14 @@ export class QuillService {
   private Quill!: any
   private $importPromise!: Promise<any>
   private count = 0
+  private document: Document
 
   constructor(
+    injector: Injector,
     @Inject(QUILL_CONFIG_TOKEN) public config: QuillConfig
   ) {
+    this.document = injector.get(DOCUMENT)
+
     if (!this.config) {
       this.config = { modules: defaultModules }
     }
@@ -26,7 +32,7 @@ export class QuillService {
         // Quill adds events listeners on import https://github.com/quilljs/quill/blob/develop/core/emitter.js#L8
         // We'd want to use the unpatched `addEventListener` method to have all event callbacks to be run outside of zone.
         // We don't know yet if the `zone.js` is used or not, just save the value to restore it back further.
-        const maybePatchedAddEventListener = document.addEventListener
+        const maybePatchedAddEventListener = this.document.addEventListener
         // There're 2 types of Angular applications:
         // 1) zone-full (by default)
         // 2) zone-less
@@ -37,9 +43,9 @@ export class QuillService {
         // The `__zone_symbol__addEventListener` is basically a native DOM API, which is not patched by zone.js, thus not even going
         // through the `zone.js` task lifecycle. You can also access the native DOM API as follows `target[Zone.__symbol__('methodName')]`.
         // eslint-disable-next-line @typescript-eslint/dot-notation
-        document.addEventListener = document['__zone_symbol__addEventListener'] || document.addEventListener
+        this.document.addEventListener = this.document['__zone_symbol__addEventListener'] || this.document.addEventListener
         const quillImport = await import('quill')
-        document.addEventListener = maybePatchedAddEventListener
+        this.document.addEventListener = maybePatchedAddEventListener
 
         this.Quill = (quillImport.default ? quillImport.default : quillImport) as any
 

--- a/projects/ngx-quill/src/lib/quill.service.ts
+++ b/projects/ngx-quill/src/lib/quill.service.ts
@@ -23,7 +23,23 @@ export class QuillService {
     this.count++
     if (!this.Quill && this.count === 1) {
       this.$importPromise = new Promise(async (resolve) => {
+        // Quill adds events listeners on import https://github.com/quilljs/quill/blob/develop/core/emitter.js#L8
+        // We'd want to use the unpatched `addEventListener` method to have all event callbacks to be run outside of zone.
+        // We don't know yet if the `zone.js` is used or not, just save the value to restore it back further.
+        const maybePatchedAddEventListener = document.addEventListener
+        // There're 2 types of Angular applications:
+        // 1) zone-full (by default)
+        // 2) zone-less
+        // The developer can avoid importing the `zone.js` package and tells Angular that he/she is responsible for running
+        // the change detection by himself. This is done by "nooping" the zone through `CompilerOptions` when bootstrapping
+        // the root module. We fallback to `document.addEventListener` if `__zone_symbol__addEventListener` is not defined,
+        // this means the `zone.js` is not imported.
+        // The `__zone_symbol__addEventListener` is basically a native DOM API, which is not patched by zone.js, thus not even going
+        // through the `zone.js` task lifecycle. You can also access the native DOM API as follows `target[Zone.__symbol__('methodName')]`.
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        document.addEventListener = document['__zone_symbol__addEventListener'] || document.addEventListener
         const quillImport = await import('quill')
+        document.addEventListener = maybePatchedAddEventListener
 
         this.Quill = (quillImport.default ? quillImport.default : quillImport) as any
 


### PR DESCRIPTION
See code comments, that won't bring any breaking change but will only improve the app performance since Quill added event listeners won't cause many change detections to run.

### Before

![before](https://user-images.githubusercontent.com/7337691/123946876-5e043800-d9a8-11eb-8fd7-0179a3b57811.png)

### After

![after](https://user-images.githubusercontent.com/7337691/123946906-63618280-d9a8-11eb-8394-45d9d29ad72a.png)
