### PR TITLE
feat: support new Angular Package Format

### DIFF
--- a/projects/ngx-quill/package.json
+++ b/projects/ngx-quill/package.json
@@ -29,11 +29,9 @@
     "ngx",
     "text editor"
   ],
+  "sideEffects": false,
   "peerDependencies": {
-    "@angular/common": "^11.0.0 || ^12.0.0 || ^13.0.0",
-    "@angular/core": "^11.0.0 || ^12.0.0 || ^13.0.0",
-    "@angular/forms": "^11.0.0 || ^12.0.0 || ^13.0.0",
-    "@angular/platform-browser": "^11.0.0 || ^12.0.0 || ^13.0.0",
+    "@angular/core": ">=13.0.0",
     "quill": "^1.3.7",
     "rxjs": "^6.5.0"
   },

--- a/projects/ngx-quill/tsconfig.lib.prod.json
+++ b/projects/ngx-quill/tsconfig.lib.prod.json
@@ -4,6 +4,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": false
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
Since Angular 13 has removed the View Engine support we can now switch to the partial compilation to accommodate with APF (Angular Package Format).

> https://angular.io/guide/angular-package-format#partial-compilation

This's a breaking change and might be published as a major version (`ngx-quill@16`).