### PR TITLE
feat: allow custom modules to be loaded on demand

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,17 @@
         "@typescript-eslint/semi": [
           "error",
           "never"
+        ],
+        "@typescript-eslint/naming-convention": [
+          "error",
+          {
+            "selector": "parameter",
+            "format": ["camelCase"],
+            "filter": {
+              "regex": "^Quill$",
+              "match": false
+            }
+          }
         ]
       }
     },

--- a/projects/ngx-quill/package.json
+++ b/projects/ngx-quill/package.json
@@ -31,9 +31,9 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@angular/core": ">=13.0.0",
+    "@angular/core": "^14.0.0",
     "quill": "^1.3.7",
-    "rxjs": "^6.5.3 || ^7.4.0"
+    "rxjs": "^7.0.0"
   },
   "contributors": [
     {

--- a/projects/ngx-quill/src/lib/quill-editor.interfaces.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.interfaces.ts
@@ -8,6 +8,18 @@ export interface CustomOption {
 }
 
 export interface CustomModule {
+  // The `implementation` may be a custom module constructor or an Observable that resolves to
+  // a custom module constructor (in case you'd want to load your custom module lazily).
+  // For instance, these options are applicable:
+  // import BlotFormatter from 'quill-blot-formatter';
+  // customModules = [
+  //   { path: 'modules/blotFormatter', implementation: BlotFormatter }
+  // ];
+  // Or:
+  // const BlotFormatter$ = defer(() => import('quill-blot-formatter').then(m => m.default))
+  // customModules = [
+  //   { path: 'modules/blotFormatter', implementation: BlotFormatter$ }
+  // ];
   implementation: any
   path: string
 }

--- a/projects/ngx-quill/src/lib/quill-view.component.ts
+++ b/projects/ngx-quill/src/lib/quill-view.component.ts
@@ -21,6 +21,7 @@ import {
   OnInit
 } from '@angular/core'
 import { Subscription } from 'rxjs'
+import { mergeMap } from 'rxjs/operators'
 
 import { CustomOption, CustomModule } from './quill-editor.interfaces'
 import {getFormat} from './helpers'
@@ -111,8 +112,9 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy, 
       return
     }
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    this.quillSubscription = this.service.getQuill().subscribe(Quill => {
+    this.quillSubscription = this.service.getQuill().pipe(
+      mergeMap((Quill) => this.service.registerCustomModules(Quill, this.customModules))
+    ).subscribe(Quill => {
       const modules = Object.assign({}, this.modules || this.service.config.modules)
       modules.toolbar = false
 
@@ -120,10 +122,6 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy, 
         const newCustomOption = Quill.import(customOption.import)
         newCustomOption.whitelist = customOption.whitelist
         Quill.register(newCustomOption, true)
-      })
-
-      this.customModules.forEach(({implementation, path}) => {
-        Quill.register(path, implementation)
       })
 
       let debug = this.debug


### PR DESCRIPTION
Hey, I've added an ability to load `customModules` on demand. E.g., if they don't have to be included into the bundle until the editor is rendered.

- Updated `.eslintrc.json` to exclude linting `Quill` argument (because it's not camelCase'd).