### PR TITLE
#1633 Updating typings for "syntax" module

### DIFF
--- a/projects/ngx-quill/config/src/quill-editor.interfaces.ts
+++ b/projects/ngx-quill/config/src/quill-editor.interfaces.ts
@@ -52,7 +52,7 @@ export interface QuillModules {
   keyboard?: {
     bindings?: any
   } | boolean
-  syntax?: boolean
+  syntax?: boolean | { highlight: any }
   toolbar?: QuillToolbarConfig | string | {
     container?: string | string[] | QuillToolbarConfig
     handlers?: {


### PR DESCRIPTION
Right now, `syntax` module is of type **boolean**.

While that works, we are required to insert `highlight.js` library in the `index.html` so Quill can work properly. The actual typings for `syntax` should be `boolean` or `object`:
```
syntax?: boolean | object;
```
This is because Quill internally uses object for the `syntax`, where the object will have `highlight` property, which is a function. This can be leveraged in order to use `highlight.js` inside the module, and not globally, which would increase the performance in case of lazy-loaded modules.

**Example:**
```typescript
import hljs from 'highlight.js/lib/common';
...
config = {
  syntax: {
    highlight: (text: string) => hljs.highlightAuto(text).value,
  },
};
```
```html
<quill-editor [modules]="config"></quill-editor>
```
This will apply syntax highlighting without importing `highlight.js` library globally.