### PR TITLE
feat: switch to signal inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/KillerCodeMonkey/ngx-quill"
   },
   "engines": {
-    "node": "20.9.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "keywords": [
     "editor",

--- a/projects/ngx-quill/src/lib/helpers.spec.ts
+++ b/projects/ngx-quill/src/lib/helpers.spec.ts
@@ -1,0 +1,11 @@
+import { raf$ } from './helpers'
+
+describe('helpers', () => {
+  it('should cancel requestAnimationFrame before it is fired', () => {
+    spyOn(globalThis, 'cancelAnimationFrame')
+    const subscription = raf$().subscribe()
+    expect(globalThis.cancelAnimationFrame).not.toHaveBeenCalled()
+    subscription.unsubscribe()
+    expect(globalThis.cancelAnimationFrame).toHaveBeenCalled()
+  })
+})

--- a/projects/ngx-quill/src/lib/helpers.ts
+++ b/projects/ngx-quill/src/lib/helpers.ts
@@ -1,6 +1,18 @@
 import { QuillFormat } from 'ngx-quill/config'
+import { Observable } from 'rxjs'
 
 export const getFormat = (format?: QuillFormat, configFormat?: QuillFormat): QuillFormat => {
   const passedFormat = format || configFormat
   return passedFormat || 'html'
+}
+
+export const raf$ = () => {
+  return new Observable(subscriber => {
+    const rafId = requestAnimationFrame(() => {
+      subscriber.next()
+      subscriber.complete()
+    })
+
+    return () => cancelAnimationFrame(rafId)
+  })
 }

--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -44,6 +44,7 @@ class CustomModule {
   [maxLength]="maxLength"
   [readOnly]="isReadOnly"
   [debounceTime]="debounceTime"
+  [trimOnValidation]="trimOnValidation"
   (onEditorCreated)="handleEditorCreated($event)"
   (onEditorChanged)="handleEditorChange($event)"
   (onContentChanged)="handleChange($event)"
@@ -61,6 +62,7 @@ class TestComponent {
   blured = false
   focusedNative = false
   bluredNative = false
+  trimOnValidation = false
   maxLength = 0
   style: {
     backgroundColor?: string
@@ -763,7 +765,7 @@ describe('Advanced QuillEditorComponent', () => {
     fixture.detectChanges()
     await fixture.whenStable()
 
-    expect(editorCmp.readOnly).toBe(false)
+    expect(editorCmp.readOnly()).toBe(false)
 
     fixture.componentInstance.isReadOnly = true
 
@@ -773,7 +775,7 @@ describe('Advanced QuillEditorComponent', () => {
     fixture.detectChanges()
     await fixture.whenStable()
 
-    expect(editorCmp.readOnly).toBe(true)
+    expect(editorCmp.readOnly()).toBe(true)
     expect(editorElem.nativeElement.querySelectorAll('div.ql-container.ql-disabled').length).toBe(1)
     expect(editorElem.nativeElement.querySelector('div[quill-editor-element]').style.height).toBe('30px')
   })
@@ -1077,7 +1079,7 @@ describe('Advanced QuillEditorComponent', () => {
     fixture.componentInstance.minLength = 8
     fixture.detectChanges()
     await fixture.whenStable()
-    expect(editorComponent.minLength).toBe(8)
+    expect(editorComponent.minLength()).toBe(8)
 
     fixture.componentInstance.title = 'Hallo1'
     fixture.detectChanges()
@@ -1097,7 +1099,7 @@ describe('Advanced QuillEditorComponent', () => {
     const editorElement = fixture.debugElement.children[0].nativeElement
 
     // set min length
-    editorComponent.minLength = 2
+    fixture.componentInstance.minLength = 2
     // change text
     editorComponent.quillEditor.setText('', 'user')
 
@@ -1125,7 +1127,7 @@ describe('Advanced QuillEditorComponent', () => {
     await fixture.whenStable()
     fixture.detectChanges()
 
-    expect(editorComponent.maxLength).toBe(3)
+    expect(editorComponent.maxLength()).toBe(3)
     expect(editorElement.className).toMatch('ng-invalid')
   })
 
@@ -1159,7 +1161,7 @@ describe('Advanced QuillEditorComponent', () => {
   it('should validate maxlength and minlength with trimming white spaces', async () => {
     // get editor component
     const editorElement = fixture.debugElement.children[0].nativeElement
-    fixture.componentInstance.editorComponent.trimOnValidation = true
+    fixture.componentInstance.trimOnValidation = true
 
     fixture.detectChanges()
     await fixture.whenStable()
@@ -1194,7 +1196,7 @@ describe('Advanced QuillEditorComponent', () => {
     await fixture.whenStable()
 
     expect(fixture.debugElement.children[0].nativeElement.className).toMatch('ng-valid')
-    expect(editorComponent.required).toBeFalsy()
+    expect(editorComponent.required()).toBeFalsy()
 
     fixture.componentInstance.required = true
     fixture.componentInstance.title = ''
@@ -1203,7 +1205,7 @@ describe('Advanced QuillEditorComponent', () => {
     await fixture.whenStable()
     fixture.detectChanges()
 
-    expect(editorComponent.required).toBeTruthy()
+    expect(editorComponent.required()).toBeTruthy()
     expect(editorElement.className).toMatch('ng-invalid')
 
     fixture.componentInstance.title = '1'
@@ -1235,8 +1237,8 @@ describe('Advanced QuillEditorComponent', () => {
     expect(toolbarFixture.debugElement.children[0].nativeElement.children[3].attributes['quill-editor-element']).toBeDefined()
 
     const editorComponent = toolbarFixture.debugElement.children[0].componentInstance
-    expect(editorComponent.required).toBe(true)
-    expect(editorComponent.customToolbarPosition).toEqual('top')
+    expect(editorComponent.required()).toBe(true)
+    expect(editorComponent.customToolbarPosition()).toEqual('top')
   })
 
   it('should add custom toolbar at the end', async () => {
@@ -1253,7 +1255,7 @@ describe('Advanced QuillEditorComponent', () => {
     expect(toolbarFixture.debugElement.children[0].nativeElement.children[3].attributes['below-quill-editor-toolbar']).toBeDefined()
 
     const editorComponent = toolbarFixture.debugElement.children[0].componentInstance
-    expect(editorComponent.customToolbarPosition).toEqual('bottom')
+    expect(editorComponent.customToolbarPosition()).toEqual('bottom')
   })
 
   it('should render custom link placeholder', async () => {

--- a/projects/ngx-quill/src/lib/quill-view-html.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-view-html.component.spec.ts
@@ -25,7 +25,7 @@ describe('Basic QuillViewHTMLComponent', () => {
     await fixture.whenStable()
 
     expect(element.querySelectorAll('.ql-editor').length).toBe(1)
-    expect(fixture.componentInstance.themeClass).toBe('ql-snow')
+    expect(fixture.componentInstance.themeClass()).toBe('ql-snow')
     const viewElement = element.querySelector('.ql-container.ql-snow.ngx-quill-view-html > .ql-editor')
     expect(viewElement).toBeDefined()
   }))

--- a/projects/ngx-quill/src/lib/quill-view.component.ts
+++ b/projects/ngx-quill/src/lib/quill-view.component.ts
@@ -1,15 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { CommonModule, isPlatformServer } from '@angular/common'
-import QuillType from 'quill'
+import { isPlatformServer } from '@angular/common'
+import type QuillType from 'quill'
 
 import {
   AfterViewInit,
   Component,
   ElementRef,
-  EventEmitter,
   Inject,
-  Input,
-  Output,
   OnChanges,
   PLATFORM_ID,
   Renderer2,
@@ -17,14 +14,20 @@ import {
   ViewEncapsulation,
   NgZone,
   SecurityContext,
-  OnDestroy
+  OnDestroy,
+  input,
+  EventEmitter,
+  Output,
+  inject,
+  DestroyRef
 } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { Subscription } from 'rxjs'
 import { mergeMap } from 'rxjs/operators'
 
 import { CustomOption, CustomModule, QuillModules } from 'ngx-quill/config'
 
-import {getFormat} from './helpers'
+import { getFormat, raf$ } from './helpers'
 import { QuillService } from './quill.service'
 import { DomSanitizer } from '@angular/platform-browser'
 
@@ -39,21 +42,22 @@ import { DomSanitizer } from '@angular/platform-browser'
   template: `
   <div quill-view-element></div>
 `,
-  standalone: true,
-  imports: [CommonModule]
+  standalone: true
 })
 export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
-  @Input() format?: 'object' | 'html' | 'text' | 'json'
-  @Input() theme?: string
-  @Input() modules?: QuillModules
-  @Input() debug?: 'warn' | 'log' | 'error' | false
-  @Input() formats?: string[] | null
-  @Input() sanitize?: boolean
-  @Input() beforeRender?: () => Promise<void>
-  @Input() strict = true
-  @Input() content: any
-  @Input() customModules: CustomModule[] = []
-  @Input() customOptions: CustomOption[] = []
+  readonly format = input<'object' | 'html' | 'text' | 'json' | undefined>(
+    undefined
+  )
+  readonly theme = input<string | undefined>(undefined)
+  readonly modules = input<QuillModules | undefined>(undefined)
+  readonly debug = input<'warn' | 'log' | 'error' | false>(false)
+  readonly formats = input<string[] | null | undefined>(undefined)
+  readonly sanitize = input<boolean | undefined>(false)
+  readonly beforeRender = input<() => Promise<void> | undefined>(undefined)
+  readonly strict = input(true)
+  readonly content = input<any>()
+  readonly customModules = input<CustomModule[]>([])
+  readonly customOptions = input<CustomOption[]>([])
 
   @Output() onEditorCreated: EventEmitter<any> = new EventEmitter()
 
@@ -61,6 +65,8 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
   editorElem!: HTMLElement
 
   private quillSubscription: Subscription | null = null
+
+  private destroyRef = inject(DestroyRef)
 
   constructor(
     public elementRef: ElementRef,
@@ -72,13 +78,13 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
   ) {}
 
   valueSetter = (quillEditor: QuillType, value: any): any => {
-    const format = getFormat(this.format, this.service.config.format)
+    const format = getFormat(this.format(), this.service.config.format)
     let content = value
     if (format === 'text') {
       quillEditor.setText(content)
     } else {
       if (format === 'html') {
-        const sanitize = [true, false].includes(this.sanitize) ? this.sanitize : (this.service.config.sanitize || false)
+        const sanitize = [true, false].includes(this.sanitize()) ? this.sanitize() : (this.service.config.sanitize || false)
         if (sanitize) {
           value = this.domSanitizer.sanitize(SecurityContext.HTML, value)
         }
@@ -110,34 +116,34 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     this.quillSubscription = this.service.getQuill().pipe(
       mergeMap((Quill) => {
-        const promises = [this.service.registerCustomModules(Quill, this.customModules)]
-        const beforeRender = this.beforeRender ?? this.service.config.beforeRender
+        const promises = [this.service.registerCustomModules(Quill, this.customModules())]
+        const beforeRender = this.beforeRender() ?? this.service.config.beforeRender
         if (beforeRender) {
           promises.push(beforeRender())
         }
         return Promise.all(promises).then(() => Quill)
       })
     ).subscribe(Quill => {
-      const modules = Object.assign({}, this.modules || this.service.config.modules)
+      const modules = Object.assign({}, this.modules() || this.service.config.modules)
       modules.toolbar = false
 
-      this.customOptions.forEach((customOption) => {
+      this.customOptions().forEach((customOption) => {
         const newCustomOption = Quill.import(customOption.import)
         newCustomOption.whitelist = customOption.whitelist
         Quill.register(newCustomOption, true)
       })
 
-      let debug = this.debug
+      let debug = this.debug()
       if (!debug && debug !== false && this.service.config.debug) {
         debug = this.service.config.debug
       }
 
-      let formats = this.formats
+      let formats = this.formats()
       if (!formats && formats === undefined) {
         formats = this.service.config.formats ?
           Object.assign({}, this.service.config.formats) : (this.service.config.formats === null ? null : undefined)
       }
-      const theme = this.theme || (this.service.config.theme ? this.service.config.theme : 'snow')
+      const theme = this.theme() || (this.service.config.theme ? this.service.config.theme : 'snow')
 
       this.editorElem = this.elementRef.nativeElement.querySelector(
         '[quill-view-element]'
@@ -149,29 +155,28 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
           formats: formats as any,
           modules,
           readOnly: true,
-          strict: this.strict,
+          strict: this.strict(),
           theme
         })
       })
 
       this.renderer.addClass(this.editorElem, 'ngx-quill-view')
 
-      if (this.content) {
-        this.valueSetter(this.quillEditor, this.content)
+      if (this.content()) {
+        this.valueSetter(this.quillEditor, this.content())
       }
 
       // The `requestAnimationFrame` triggers change detection. There's no sense to invoke the `requestAnimationFrame` if anyone is
       // listening to the `onEditorCreated` event inside the template, for instance `<quill-view (onEditorCreated)="...">`.
-      if (!this.onEditorCreated.observers.length) {
+      if (!this.onEditorCreated.observed) {
         return
       }
 
       // The `requestAnimationFrame` will trigger change detection and `onEditorCreated` will also call `markDirty()`
       // internally, since Angular wraps template event listeners into `listener` instruction. We're using the `requestAnimationFrame`
       // to prevent the frame drop and avoid `ExpressionChangedAfterItHasBeenCheckedError` error.
-      requestAnimationFrame(() => {
+      raf$().pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
         this.onEditorCreated.emit(this.quillEditor)
-        this.onEditorCreated.complete()
       })
     })
   }


### PR DESCRIPTION
This commit switches inputs to signal inputs to be compatible with zoneless change detection because everything should be a signal primitive. As such, its changes may be caught by the execution context. Every time a signal changes, it would schedule a change detection event, even in zoneless mode.

I didn't update `@Output()` to `output` because we still use `.observed` properties.