### PR TITLE
fix: handle empty value returned by getSemanticHTML

### DIFF
--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -740,6 +740,19 @@ describe('Reactive forms integration', () => {
     expect(fixture.componentInstance.formControl.value).toEqual('a')
     expect(fixture.componentInstance.formControl.invalid).toBeTruthy()
   })
+
+  it('should write the defaultEmptyValue when editor is emptied', async () => {
+    fixture.detectChanges()
+    await fixture.whenStable()
+
+
+    fixture.componentInstance.editor.quillEditor.setText('', 'user')
+    fixture.detectChanges()
+    await fixture.whenStable()
+
+    // default empty value is null
+    expect(fixture.componentInstance.formControl.value).toEqual(null)
+  })
 })
 
 describe('Advanced QuillEditorComponent', () => {

--- a/projects/ngx-quill/src/lib/quill-editor.component.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.ts
@@ -171,7 +171,7 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
 
   valueGetter = input((quillEditor: QuillType): string | any => {
     let html: string | null = quillEditor.getSemanticHTML()
-    if (html === '<p><br></p>' || html === '<div><br></div>') {
+    if (this.isEmptyValue(html)) {
       html = this.defaultEmptyValue()
     }
     let modelValue: string | Delta | null = html
@@ -421,7 +421,7 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
     const content = this.quillEditor.getContents()
 
     let html: string | null = this.quillEditor.getSemanticHTML()
-    if (html === '<p><br></p>' || html === '<div><br></div>') {
+    if (this.isEmptyValue(html)) {
       html = this.defaultEmptyValue()
     }
 
@@ -471,7 +471,7 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
       const content = this.quillEditor.getContents()
 
       let html: string | null = this.quillEditor.getSemanticHTML()
-      if (html === '<p><br></p>' || html === '<div><br></div>') {
+      if (this.isEmptyValue(html)) {
         html = this.defaultEmptyValue()
       }
 
@@ -740,6 +740,10 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
       this.subscription.unsubscribe()
       this.subscription = null
     }
+  }
+
+  private isEmptyValue(html: string | null) {
+    return html === '<p></p>' || html === '<div></div>' || html === '<p><br></p>' || html === '<div><br></div>'
   }
 }
 


### PR DESCRIPTION
A regression was spotted by our team when updating to the lastest ngx-quill version, where required form controls applied on quill editors were no longer be marked invalid when emptied.

It looks like `getSemanticHTML()` can return `<p></p>` when the editor is emptied (at least when it is emptied programatically using `setText('')`). This commit augments the "empty" check to handle this possible value and `<div></div>`. A unit test has been added to reproduce this issue.