### PR TITLE
Fix QuillViewComponent formats issue

### DIFF
--- a/projects/ngx-quill/src/lib/quill-editor.component.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.ts
@@ -299,8 +299,8 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
       this.zone.runOutsideAngular(() => {
         this.quillEditor = new Quill(this.editorElem, {
           bounds,
-          debug: debug as any,
-          formats: formats as any,
+          debug,
+          formats,
           modules,
           placeholder,
           readOnly,

--- a/projects/ngx-quill/src/lib/quill-view.component.ts
+++ b/projects/ngx-quill/src/lib/quill-view.component.ts
@@ -140,8 +140,7 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
 
       let formats = this.formats()
       if (!formats && formats === undefined) {
-        formats = this.service.config.formats ?
-          Object.assign({}, this.service.config.formats) : (this.service.config.formats === null ? null : undefined)
+        formats = this.service.config.formats ? [...this.service.config.formats] : (this.service.config.formats === null ? null : undefined)
       }
       const theme = this.theme() || (this.service.config.theme ? this.service.config.theme : 'snow')
 
@@ -151,8 +150,8 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
 
       this.zone.runOutsideAngular(() => {
         this.quillEditor = new Quill(this.editorElem, {
-          debug: debug as any,
-          formats: formats as any,
+          debug,
+          formats,
           modules,
           readOnly: true,
           strict: this.strict(),


### PR DESCRIPTION
There currently is an issue where if you have custom `formats` (I had `formats: ['link', 'size', 'italic', 'bold', 'list', 'header', 'underline', 'indent', 'align', 'color', 'image', 'strong'],`) configured in the `QuillModule.forRoot()` method and you don't pass in custom `formats` to the view component. This throws the following runtime error when trying to render `<quill-view />`:

```
TypeError: formats.forEach is not a function at createRegistryWithFormats (createRegistryWithFormats.js:10:11)
```

This is because the `formats` that's passed into `Quill` from the `QuillViewComponent` component can be an object, as opposed to a `string[]`, when `formats` passed into the component is `undefined` (see line [143](https://github.com/KillerCodeMonkey/ngx-quill/blob/master/projects/ngx-quill/src/lib/quill-view.component.ts#L143))

My PR uses the same logic found in the editor component, which does have the correct implementation.