### PR TITLE
fix: beforeRender accpet return type Promise<any>

### DIFF
--- a/projects/ngx-quill/config/src/quill-editor.interfaces.ts
+++ b/projects/ngx-quill/config/src/quill-editor.interfaces.ts
@@ -77,7 +77,7 @@ export interface QuillConfig {
   modules?: QuillModules
   placeholder?: string
   readOnly?: boolean
-  registry?: QuillOptions['registry'] // added in quill2 result of const registry = new Parchment.Registry(); 
+  registry?: QuillOptions['registry'] // added in quill2 result of const registry = new Parchment.Registry();
   theme?: string
   // Custom Config to track all changes or only changes by 'user'
   trackChanges?: 'user' | 'all'
@@ -86,7 +86,7 @@ export interface QuillConfig {
   sanitize?: boolean
   // A function, which is executed before the Quill editor is rendered, this might be useful
   // for lazy-loading CSS.
-  beforeRender?: () => Promise<void>
+  beforeRender?: () => Promise<any>
 }
 
 export const QUILL_CONFIG_TOKEN = new InjectionToken<QuillConfig>('config', {

--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -1450,7 +1450,7 @@ describe('QuillEditor - beforeRender', () => {
   class BeforeRenderTestComponent {
     @ViewChild(QuillEditorComponent, { static: true }) editor!: QuillEditorComponent
 
-    beforeRender?: () => Promise<void>
+    beforeRender?: () => Promise<any>
   }
 
   let fixture: ComponentFixture<BeforeRenderTestComponent>

--- a/projects/ngx-quill/src/lib/quill-editor.component.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.ts
@@ -94,7 +94,7 @@ export abstract class QuillEditorBase implements AfterViewInit, ControlValueAcce
   readonly formats = input<string[] | null | undefined>(undefined)
   readonly customToolbarPosition = input<'top' | 'bottom'>('top')
   readonly sanitize = input<boolean | undefined>(undefined)
-  readonly beforeRender = input<() => Promise<void> | undefined>(undefined)
+  readonly beforeRender = input<() => Promise<any> | undefined>(undefined)
   readonly styles = input<any>(null)
   readonly registry = input<QuillOptions['registry']>(
     undefined

--- a/projects/ngx-quill/src/lib/quill-view.component.ts
+++ b/projects/ngx-quill/src/lib/quill-view.component.ts
@@ -53,7 +53,7 @@ export class QuillViewComponent implements AfterViewInit, OnChanges, OnDestroy {
   readonly debug = input<'warn' | 'log' | 'error' | false>(false)
   readonly formats = input<string[] | null | undefined>(undefined)
   readonly sanitize = input<boolean | undefined>(undefined)
-  readonly beforeRender = input<() => Promise<void> | undefined>(undefined)
+  readonly beforeRender = input<() => Promise<any> | undefined>(undefined)
   readonly strict = input(true)
   readonly content = input<any>()
   readonly customModules = input<CustomModule[]>([])


### PR DESCRIPTION
Hi, I found beforeRender only accept `() => Promise<void>`, but in my use case, I have to render quill after every async sources loaded, beforeRender maybe just need a resoved status instead of specific `void` type

![CleanShot 2024-08-22 at 11 32 59@2x](https://github.com/user-attachments/assets/e34f9a79-cca8-4a97-b5af-ad045d306999)
