### PR TITLE
fix: reduce asynchronous stuff to resolve flickering

### DIFF
--- a/projects/ngx-quill/config/src/quill-editor.interfaces.ts
+++ b/projects/ngx-quill/config/src/quill-editor.interfaces.ts
@@ -1,7 +1,8 @@
 import { InjectionToken } from '@angular/core'
+import type { QuillOptions } from 'quill'
+import type { Observable } from 'rxjs'
 
 import { defaultModules } from './quill-defaults'
-import type { QuillOptions } from 'quill'
 
 export interface CustomOption {
   import: string
@@ -62,6 +63,8 @@ export interface QuillModules {
 
 export type QuillFormat = 'object' | 'json' | 'html' | 'text'
 
+export type QuillBeforeRender = (() => Promise<any>) | (() => Observable<any>)
+
 export interface QuillConfig {
   bounds?: HTMLElement | string
   customModules?: CustomModule[]
@@ -82,7 +85,7 @@ export interface QuillConfig {
   sanitize?: boolean
   // A function, which is executed before the Quill editor is rendered, this might be useful
   // for lazy-loading CSS.
-  beforeRender?: () => Promise<any>
+  beforeRender?: QuillBeforeRender
 }
 
 export const QUILL_CONFIG_TOKEN = new InjectionToken<QuillConfig>('config', {

--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -1457,7 +1457,7 @@ describe('QuillEditor - beforeRender', () => {
       imports: [QuillModule.forRoot(config)],
     })
 
-    spyOn(config, 'beforeRender')
+    spyOn(config, 'beforeRender').and.callThrough()
 
     fixture = TestBed.createComponent(BeforeRenderTestComponent)
     fixture.detectChanges()
@@ -1474,11 +1474,11 @@ describe('QuillEditor - beforeRender', () => {
       imports: [QuillModule.forRoot(config)],
     })
 
-    spyOn(config, 'beforeRender')
+    spyOn(config, 'beforeRender').and.callThrough()
 
     fixture = TestBed.createComponent(BeforeRenderTestComponent)
     fixture.componentInstance.beforeRender = () => Promise.resolve()
-    spyOn(fixture.componentInstance, 'beforeRender')
+    spyOn(fixture.componentInstance, 'beforeRender').and.callThrough()
     fixture.detectChanges()
     await fixture.whenStable()
 


### PR DESCRIPTION
In this commit, we introduce a slightly smarter approach to handling custom module registration and executing the `beforeRender` function. The current issue is that the `quill-editor-toolbar` may be projected before the editor is rendered due to the `Promise.all` in `mergeMap`. This is noticeable on slower devices, where the toolbar appears first (without styles), and then after a microtask delay, Quill is created.

Switching to observables resolves this issue because observables can emit both synchronously and asynchronously, and most observables can cache their emissions using `shareReplay`, ensuring that subsequent emissions are always synchronous.