### PR TITLE
refactor: move `quill` to separate entry point

### DIFF
--- a/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
+++ b/projects/ngx-quill/src/lib/quill-editor.component.spec.ts
@@ -9,11 +9,6 @@ import { QuillEditorComponent } from './quill-editor.component'
 import Quill from 'quill'
 import { QuillModule } from './quill.module'
 
-window.setTimeout = ((cb) => {
-  cb()
-  return 0
-}) as any
-
 // const Quill = require('quill')
 
 class CustomModule {

--- a/projects/ngx-quill/src/lib/quill.service.ts
+++ b/projects/ngx-quill/src/lib/quill.service.ts
@@ -38,13 +38,9 @@ export class QuillService {
       this.document.addEventListener =
         this.document['__zone_symbol__addEventListener'] ||
         this.document.addEventListener
-      const quillImport = await import('quill')
+      const { Quill } = await import('./quill')
       this.document.addEventListener = maybePatchedAddEventListener
-
-      this.Quill = (
-        // seems like esmodules have nested "default"
-        (quillImport.default as any)?.default ?? quillImport.default ?? quillImport
-      ) as any
+      this.Quill = Quill
     }
 
     // Only register custom options and modules once

--- a/projects/ngx-quill/src/lib/quill.ts
+++ b/projects/ngx-quill/src/lib/quill.ts
@@ -1,0 +1,7 @@
+// Represents a tree-shakable entry-point.
+// When we use `import(...)` with `quill` directly,
+// it bundles all the features from `quill`.
+
+import Quill from 'quill'
+
+export { Quill }


### PR DESCRIPTION
Modules that are wrapped with a dynamic import are always marked as side-effectful. For example, if we do `import('lodash-es').then(m => m.sortBy(...))`, it will bundle **all** functions from that module, regardless of whether it's in ESM format or not. This happens because the compiler cannot detect which static imports are used from the module.

Having separate entry points helps the compiler detect static imports and tree-shake functions and classes that are not referenced. A static import like `import { ... } from 'quill'` has no side effects, and only the `quill.ts` file is marked as side-effectful.