### PR TITLE
Improve Quill toolbar handlers typing

### DIFF
--- a/projects/ngx-quill/config/src/quill-editor.interfaces.ts
+++ b/projects/ngx-quill/config/src/quill-editor.interfaces.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core'
 import type { QuillOptions } from 'quill'
-import Toolbar from 'quill/modules/toolbar'
+import type Toolbar from 'quill/modules/toolbar'
 import type { Observable } from 'rxjs'
 
 import { defaultModules } from './quill-defaults'


### PR DESCRIPTION
This pull request aims to improve the typing for the Quill toolbar handlers. Right now, when implementing a handler in the `this` object is untyped, which isn't ideal. The proposed solution addresses this and correctly types `this`, improving type safety!

Reference in the Quill source code:
https://github.com/slab/quill/blob/main/packages/quill/src/modules/toolbar.ts#L10

Added thought: since Quill v2 is completely rewritten in TypeScript, I'm wondering if there's still a need for the `quill-editor.interfaces.ts` file at all? In an ideal situation we would just rely on the provided upstream types and not need a manually maintained interface file?